### PR TITLE
Make expiration check optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ jwt.readJWTHeader(token, function(err, header) {
 
 ## Configuration
 
-* expiration: Expiration time in seconds to generate exp field in token.
+* expiration: Expiration time in seconds to generate exp field in token (this functionality can be disabled by setting the value to 0).
 * futureTolerance: Tolerance seconds to find out if a jwt comes from the future or not.
 
 ## Development information

--- a/lib/jwt-utils.js
+++ b/lib/jwt-utils.js
@@ -322,8 +322,10 @@ module.exports = function(configuration) {
   }
 
   function makePayload(payload) {
-    payload.iat = payload.iat || parseInt(new Date().getTime() / 1000, 10);
-    payload.exp = payload.exp || payload.iat + config.expiration;
+    if (config.expiration !== 0) {
+      payload.iat = payload.iat || parseInt(new Date().getTime() / 1000, 10);
+      payload.exp = payload.exp || payload.iat + config.expiration;
+    }
     return payload;
   }
 
@@ -346,14 +348,16 @@ module.exports = function(configuration) {
     } else {
       if (payload.hasOwnProperty('iat')) {
         return cb(errors.INVALID_IAT());
-      } else {
+      } else if (config.expiration !== 0) {
         return cb(errors.MISSING_IAT(), token);
       }
     }
 
-    var expLimit = iatParsed + config.expiration;
-    if (expLimit <= currentDate) {
-      return cb(errors.NO_FRESH_JWT(), token);
+    if (config.expiration !== 0) {
+      var expLimit = iatParsed + config.expiration;
+      if (expLimit <= currentDate) {
+        return cb(errors.NO_FRESH_JWT(), token);
+      }
     }
 
     if (payload.exp) {
@@ -376,7 +380,12 @@ module.exports = function(configuration) {
   }
 
   if (configuration) {
-    config.expiration = configuration.expiration || DEFAULT_CONFIG.expiration;
+    if (configuration.expiration || configuration.expiration === 0) {
+      config.expiration = configuration.expiration;
+    } else {
+      config.expiration = DEFAULT_CONFIG.expiration;
+    }
+
     config.futureTolerance = configuration.futureTolerance || DEFAULT_CONFIG.futureTolerance;
   } else {
     config = DEFAULT_CONFIG;

--- a/test/unit/jwt-utils-test.js
+++ b/test/unit/jwt-utils-test.js
@@ -833,4 +833,41 @@ describe('Jwt Utils Tests', function() {
     });
   });
 
+  it('should not check expiry with config.expiration set to 0', function() {
+    var jwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.Gfx6VO9tcxwk6xqx9yYzSfebfeakZp5JYIgP_edcw_A';
+    var hashKey = '796f75722d3235362d6269742d736563726574';
+
+    var jwtUtilsMod = jwt({expiration: 0});
+
+    jwtUtilsMod.readJWT(jwtToken, hashKey, function(err, token) {
+      expect(err).to.not.exist;
+    });
+  });
+
+  it('should check expiry with config.expiration set to a value other than 0', function() {
+    var jwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.Gfx6VO9tcxwk6xqx9yYzSfebfeakZp5JYIgP_edcw_A';
+    var hashKey = '796f75722d3235362d6269742d736563726574';
+
+    var jwtUtilsMod = jwt({expiration: 1});
+
+    jwtUtilsMod.readJWT(jwtToken, hashKey, function(err, token) {
+      expect(err).to.exist;
+    });
+  });
+
+  it('should check iat and exp if present, even with config.expiration set to 0', function() {
+    var jwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIwLCJleHAiOjE1MTYyMzkwMjF9.H_PgIMtvx7m9-vwIc3JBL6FBUEowa9MSYg7bx-BPmBQ';
+    var hashKey = '796f75722d3235362d6269742d736563726574';
+
+    var clock = sinon.useFakeTimers(0, 'Date');
+    clock.tick((1516239022000 + 1) * 1000);
+
+    var jwtUtilsMod = jwt({expiration: 0});
+
+    jwtUtilsMod.readJWT(jwtToken, hashKey, function(err, token) {
+      expect(err).to.exist;
+      clock.restore();
+    });
+  });
+
 });


### PR DESCRIPTION
When configuration.expiration is set to 0, the iat parameter will not be
checked unless an exp parameter is present in the payload